### PR TITLE
Adding Factory Design Pattern

### DIFF
--- a/Creational/Factory/Makefile
+++ b/Creational/Factory/Makefile
@@ -1,0 +1,23 @@
+CXX		  := g++
+CXX_FLAGS := -Wall -Wextra -std=c++17 -ggdb
+
+BIN		:= bin
+SRC		:= src
+INCLUDE	:= include
+LIB		:= lib
+
+LIBRARIES	:=
+EXECUTABLE	:= main.out
+
+
+all: $(BIN)/$(EXECUTABLE)
+
+run: clean all
+	clear
+	./$(BIN)/$(EXECUTABLE)
+
+$(BIN)/$(EXECUTABLE): $(SRC)/*.cpp
+	$(CXX) $(CXX_FLAGS) -I$(INCLUDE) -L$(LIB) $^ -o $@ $(LIBRARIES)
+
+clean:
+	-rm $(BIN)/*

--- a/Creational/Factory/include/Animal.hpp
+++ b/Creational/Factory/include/Animal.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <iostream>
+
+class Animal {
+
+friend class AnimalFactory;
+
+public:
+    void makeSound() { std::cout << sound << std::endl; }
+
+protected:
+    std::string sound;
+    Animal(){ sound = "..."; };
+};

--- a/Creational/Factory/include/AnimalFactory.hpp
+++ b/Creational/Factory/include/AnimalFactory.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+#include <Dog.hpp>
+#include <Cat.hpp>
+
+class AnimalFactory {
+
+public:
+    static Animal createAnimal(std::string type);
+
+private:
+    AnimalFactory();
+};

--- a/Creational/Factory/include/Cat.hpp
+++ b/Creational/Factory/include/Cat.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Animal.hpp>
+
+class Cat : public Animal {
+
+friend class AnimalFactory;
+
+public:
+    void breakThings();
+
+private:
+    Cat();
+};

--- a/Creational/Factory/include/Dog.hpp
+++ b/Creational/Factory/include/Dog.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Animal.hpp"
+
+class Dog : public Animal {
+
+friend class AnimalFactory;
+
+public:
+    void lickOwner();
+
+protected:
+    Dog();
+};

--- a/Creational/Factory/src/AnimalFactory.cpp
+++ b/Creational/Factory/src/AnimalFactory.cpp
@@ -1,0 +1,13 @@
+#include "AnimalFactory.hpp"
+
+AnimalFactory::AnimalFactory() {}
+
+Animal AnimalFactory::createAnimal(std::string type)
+{
+    if(type == "Dog")
+        return Dog();
+    else if(type == "Cat")
+        return Cat();
+    else
+        return Animal();
+}

--- a/Creational/Factory/src/Cat.cpp
+++ b/Creational/Factory/src/Cat.cpp
@@ -1,0 +1,11 @@
+#include "Cat.hpp"
+
+Cat::Cat()
+{
+    sound = "Miau!";
+}
+
+void Cat::breakThings()
+{
+    std::cout << "You like that vase? what a shame, Miau" << std::endl;
+}

--- a/Creational/Factory/src/Dog.cpp
+++ b/Creational/Factory/src/Dog.cpp
@@ -1,0 +1,11 @@
+#include "Dog.hpp"
+
+Dog::Dog()
+{
+    sound = "Au au au!";
+}
+
+void Dog::lickOwner()
+{
+    std::cout << "*Dog licks owner*" << std::endl;
+}

--- a/Creational/Factory/src/main.cpp
+++ b/Creational/Factory/src/main.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+
+#include <AnimalFactory.hpp>
+
+int main()
+{
+    Animal dog1 = AnimalFactory::createAnimal("Dog");
+    Animal cat1 = AnimalFactory::createAnimal("Cat");
+    Animal animal1 = AnimalFactory::createAnimal("anything that is not Dog or Cat");
+
+    dog1.makeSound();
+    cat1.makeSound();
+    animal1.makeSound();
+
+    auto dog2 = static_cast<Dog*>(&dog1);
+    dog2->lickOwner();
+
+    auto cat2 = static_cast<Cat*>(&cat1);
+    cat2->breakThings();
+
+    std::cout << "Hello Easy C++ project!" << std::endl;
+}


### PR DESCRIPTION
The factory design pattern is used to handle the responsabilities of creating an object of classes to another class, the factory class.
With this is possible to hide the interface of the desired classes.
In this example, the client cannot call the constructor of Animal, Dog and Cat, the only way to obtain an object is to use the Factory class.